### PR TITLE
Fix dns_cpanel.sh not taking multiple domains into account

### DIFF
--- a/dnsapi/dns_cpanel.sh
+++ b/dnsapi/dns_cpanel.sh
@@ -120,7 +120,7 @@ _myget() {
 
 _get_root() {
   _myget 'json-api/cpanel?cpanel_jsonapi_apiversion=2&cpanel_jsonapi_module=ZoneEdit&cpanel_jsonapi_func=fetchzones'
-  _domains=$(echo "$_result" | sed 's/.*\(zones.*\[\).*/\1/' | cut -d':' -f2 | sed 's/"//g' | sed 's/{//g')
+  _domains=$(echo "$_result" | grep -Eio '\"([a-z0-9]+[a-z0-9-]*[a-z0-9]+\.)+(([a-z]+)|(xn--[a-z0-9]+))\.?\"\s*:\s*\[\s*[^]]' | cut -d':' -f1 | sed 's/[\" ]//g')
   _debug "_result is: $_result"
   _debug "_domains is: $_domains"
   if [ -z "$_domains" ]; then


### PR DESCRIPTION
The previous sed and cut combination led to at most one domain being extracted from the cPanel API call. This new grep, cut and sed combination aims to extract all domains whose zone is not empty.